### PR TITLE
fix: varints are LSB

### DIFF
--- a/varint.go
+++ b/varint.go
@@ -42,10 +42,10 @@ func FromUvarint(buf []byte) (uint64, int, error) {
 		if b < 0x80 {
 			if i > 9 || i == 9 && b > 1 {
 				return 0, 0, ErrOverflow
+			} else if b == 0 && s > 0 {
+				return 0, 0, ErrNotMinimal
 			}
 			return x | uint64(b)<<s, i + 1, nil
-		} else if b == 0x80 && x == 0 {
-			return 0, 0, ErrNotMinimal
 		}
 		x |= uint64(b&0x7f) << s
 		s += 7
@@ -73,10 +73,12 @@ func ReadUvarint(r io.ByteReader) (uint64, error) {
 		if b < 0x80 {
 			if i > 9 || i == 9 && b > 1 {
 				return 0, ErrOverflow
+			} else if b == 0 && s > 0 {
+				// we should never _finish_ on a 0 byte if we
+				// have more than one byte.
+				return 0, ErrNotMinimal
 			}
 			return x | uint64(b)<<s, nil
-		} else if b == 0x80 && x == 0 {
-			return 0, ErrNotMinimal
 		}
 		x |= uint64(b&0x7f) << s
 		s += 7

--- a/varint_test.go
+++ b/varint_test.go
@@ -15,6 +15,16 @@ func checkVarint(t *testing.T, x uint64) {
 	if size != expected {
 		t.Fatalf("expected varintsize of %d to be %d, got %d", x, expected, size)
 	}
+	xi, n, err := FromUvarint(buf)
+	if err != nil {
+		t.Fatal("decoding error", err)
+	}
+	if n != size {
+		t.Fatal("read the wrong size")
+	}
+	if xi != x {
+		t.Fatal("expected a different result")
+	}
 }
 
 func TestVarintSize(t *testing.T) {
@@ -44,7 +54,8 @@ func TestOverflow(t *testing.T) {
 }
 
 func TestNotMinimal(t *testing.T) {
-	i, n, err := FromUvarint([]byte{0x80, 0x01})
+	varint := []byte{0x81, 0x00}
+	i, n, err := FromUvarint(varint)
 	if err != ErrNotMinimal {
 		t.Error("expected an error")
 	}
@@ -53,6 +64,29 @@ func TestNotMinimal(t *testing.T) {
 	}
 	if i != 0 {
 		t.Error("expected i = 0")
+	}
+	i, n = binary.Uvarint(varint)
+	if n != len(varint) {
+		t.Error("expected to read entire buffer")
+	}
+	if i != 1 {
+		t.Error("expected varint 1")
+	}
+}
+
+func TestNotMinimalRead(t *testing.T) {
+	varint := bytes.NewBuffer([]byte{0x81, 0x00})
+	i, err := ReadUvarint(varint)
+	if err != ErrNotMinimal {
+		t.Error("expected an error")
+	}
+	if i != 0 {
+		t.Error("expected i = 0")
+	}
+	varint = bytes.NewBuffer([]byte{0x81, 0x00})
+	i, err = binary.ReadUvarint(varint)
+	if i != 1 {
+		t.Error("expected varint 1")
 	}
 }
 


### PR DESCRIPTION
Got this completely wrong. To check for minimal encoding, we need to verify that either:

1. There is exactly one 0.
2. The MSB of the varint isn't a 0.