### PR TITLE
tests for unbounded uvarint streams.

### DIFF
--- a/varint_test.go
+++ b/varint_test.go
@@ -34,6 +34,35 @@ func TestVarintSize(t *testing.T) {
 	}
 }
 
+func TestOverflow_9thSignalsMore(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{
+		0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff,
+		0x80,
+	})
+
+	_, err := ReadUvarint(buf)
+	if err != ErrOverflow {
+		t.Fatalf("expected ErrOverflow, got: %s", err)
+	}
+}
+
+func TestOverflow_ReadBuffer(t *testing.T) {
+	buf := bytes.NewBuffer([]byte{
+		0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff,
+	})
+
+	_, err := ReadUvarint(buf)
+	if err != ErrOverflow {
+		t.Fatalf("expected ErrOverflow, got: %s", err)
+	}
+}
+
 func TestOverflow(t *testing.T) {
 	i, n, err := FromUvarint(
 		[]byte{


### PR DESCRIPTION
Now that the Go [uvarint vulnerability is public](https://groups.google.com/g/golang-announce/c/NyPIaucMgXo/m/GdsyQP6QAAAJ), and [we have disclosed to the full libp2p user base](https://discuss.libp2p.io/t/notice-upstream-security-vulnerability-please-upgrade-go-and-go-libp2p-immediately/629), I am submitting the unit tests I held back for security reasons when patching via #6, as they clearly illustrate the problem. 